### PR TITLE
Feat/allow lookup for new entities in same tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## WIP
+
+- Allow ID lookup (when creating or referring to new entities with `:id`) to include entities being created in the same transaction
+
 ## [2.3.0] - 2022-03-19
 ### Changed
 - All keywords in the `tg` namespace have been updated to use the `a` namespace. This keeps them short, and makes more sense for the project, which no longer has anything to do with "ThreatGrid".

--- a/src/asami/entities/writer.cljc
+++ b/src/asami/entities/writer.cljc
@@ -82,7 +82,7 @@
 (defn lookup-ref?
   "Tests if i is a lookup ref"
   [i]
-  (and (vector? i) (keyword? (first i)) (= 2 (count i))))
+  (and (vector? i) (= 2 (count i)) (#{:db/id :db/ident :id} (first i))))
 
 (defn resolve-ref
   [[prop id]]


### PR DESCRIPTION
A follow up on #2 that unifies what we put in id-map

This is not intended to replace #2 but to present an alternative that we can discuss.

When we have an ident such as `[:id "whatever"]` then `entity-triples` used by the map form of tx-data would insert just "whatever" into the id-map `ids` upon creating the entity. That is contrary to the code just added in 9ea60eb, which puts the whole ident in there.

We want to unify both so that references will be resolved correctly no matter what (map x triplets) form is used.

This commits bows to the wisdom of entity-triples and puts only the ident's value into the id-map.

BEWARE: An ident's value can be _anything_. Thus it puts us at risk when we do the `(ids %)` lookup at L208 that we will replace some E/A/V value that was not meant as a reference.