### PR TITLE
A follow up on #2 that unifies what we put in id-map

### DIFF
--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -227,22 +227,28 @@
       (is (= {:person/name "Betty" :person/age 43} betty)))))
 
 (deftest test-db-add-with-lookup-ref-creates-entity
+  ;; Notice the entities are provided in the correct order - dependants after those they depend on (refer to)
   (let [{d :db-after} @(transact *conn* {:tx-data [[:db/add [:id "bobid"] :id "bobid"]
                                                    [:db/add [:id "bobid"] :person/name "Bob"]
                                                    [:db/add [:id "bobid"] :person/age 42]
 
+                                                   {:id "maryid" :person/name "Mary", :person/age 18}
+
                                                    [:db/add [:db/ident "bettyid"] :db/ident "bettyid"]
                                                    [:db/add [:db/ident "bettyid"] :person/name "Betty"]
                                                    [:db/add [:db/ident "bettyid"] :person/age 43]
-                                                   [:db/add [:db/ident "bettyid"] :person/friend [:id "bobid"]]]})
+                                                   [:db/add [:db/ident "bettyid"] :person/friend [:id "bobid"]]
+                                                   [:db/add [:db/ident "bettyid"] :person/bff [:id "maryid"]]]})
         bob (entity d "bobid")
+        mary (entity d "maryid")
         betty (entity d "bettyid" true)
         bob-node-ref (a/q '[:find ?n . :where [?n :id "bobid"]] d)
         betty-node-ref (a/q '[:find ?n . :where [?n :db/ident "bettyid"]] d)]
     (is (keyword? bob-node-ref) "We should end up with a proper node id and not `[:id \"bobid\"]` used as the node id")
     (is (keyword? betty-node-ref) "We should end up with a proper node id and not `[:db/ident \"bettyid\"]` used as the node id")
     (is (= {:id "bobid" :person/name "Bob" :person/age 42} bob))
-    (is (= {:person/name "Betty" :person/age 43 :person/friend bob} betty))))
+    ;; FIXME The problem is that the ID map becomes `{[:id bobid] :a/node-28618, maryid :a/node-28619}` - ie mary is in wrong form ?!
+    (is (= {:person/name "Betty" :person/age 43 :person/friend bob, :person/bff mary} betty))))
 
 (deftest test-entity
   (let [c *conn*


### PR DESCRIPTION
This is not intended to replace #2 but to present an alternative that we can discuss.

When we have an ident such as `[:id "whatever"]` then `entity-triples` used by the map form of tx-data would insert just "whatever" into the id-map `ids` upon creating the entity. That is contrary to the code just added in 9ea60eb, which puts the whole ident in there.

We want to unify both so that references will be resolved correctly no matter what (map x triplets) form is used.

This commits bows to the wisdom of entity-triples and puts only the ident's value into the id-map.

BEWARE: An ident's value can be _anything_. Thus it puts us at risk when we do the `(ids %)` lookup at L208 that we will replace some E/A/V value that was not meant as a reference.